### PR TITLE
Iteration 6

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,3 +152,21 @@ ______________________________________________________
 5. If the user navigates away from the Unmotivational Posters view after deleting some posters, those posters should still be gone when they navigate back to that view.
 
    - This was achieved by ensuring that the `unmotivationalPosters` array is updated and maintained in its current state, even when the user navigates away from and back to the Unmotivational Posters view.
+
+
+#### Iteration 6:
+
+
+1. Styling UPDATES:
+
+   -Using CSS, make the styling/format of the new “Unmotivational Posters” button (on the main page) and the “Back to Main” button (on the Unmotivational Posters page) match the other buttons throughout the app.
+
+   -Using CSS flexbox (not grid), control the layout of the unmotivational posters to match the comp provided here. Note: the number of posters you see in each row will flex based on the width of the screen, thats a good thing!
+
+   -Using CSS, make the style and size of the unmotivational posters match the comp provided here. You’ll notice they should look slightly different than the saved posters.
+
+
+<!-- ***Hint:
+Consider the existing html and css as you style this view. Are there places you can reuse existing classes/styling? Ensure your work doesn’t change the styling of the other parts of the app (like saved posters).
+
+When you’re done, take a moment to see how the layout of the unmotivational posters flexes to adapt to the width available when you drag your dev console to be wider/narrower while on the unmotivational view. Compare that to the saved view which uses grid.*** -->

--- a/README.md
+++ b/README.md
@@ -161,12 +161,13 @@ ______________________________________________________
 
    -Using CSS, make the styling/format of the new “Unmotivational Posters” button (on the main page) and the “Back to Main” button (on the Unmotivational Posters page) match the other buttons throughout the app.
 
+      - This was achieved by applying the same styles used for other buttons in the app to the new “Unmotivational Posters” button and the “Back to Main” button, ensuring consistency in appearance.
+
    -Using CSS flexbox (not grid), control the layout of the unmotivational posters to match the comp provided here. Note: the number of posters you see in each row will flex based on the width of the screen, thats a good thing!
+
+      - This was achieved by using CSS flexbox to create a responsive layout for the unmotivational posters, allowing the number of posters per row to adjust based on the screen width.
 
    -Using CSS, make the style and size of the unmotivational posters match the comp provided here. You’ll notice they should look slightly different than the saved posters.
 
+      - This was achieved by updating the CSS to apply grey padding, rounded edges, and black text color for the unmotivational posters, differentiating them from the saved posters.
 
-<!-- ***Hint:
-Consider the existing html and css as you style this view. Are there places you can reuse existing classes/styling? Ensure your work doesn’t change the styling of the other parts of the app (like saved posters).
-
-When you’re done, take a moment to see how the layout of the unmotivational posters flexes to adapt to the width available when you drag your dev console to be wider/narrower while on the unmotivational view. Compare that to the saved view which uses grid.*** -->

--- a/styles.css
+++ b/styles.css
@@ -151,10 +151,37 @@ button:hover {
 }
 
 .unmotivational-posters-grid {
-  display: grid;
-  grid-template-columns: repeat(3, 1fr);  /*  this will create 3 columns, 1fr is used to make the columns equal width */
-  grid-gap: 20px;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 20px;
   padding: 20px;
 }
 
-/* Reuse the same styles for mini-poster */
+.unmotivational-posters .mini-poster {
+  background: black;
+  color: white;
+  height: 340px;
+  padding: 25px;
+  width: 425px;
+}
+
+.unmotivational-posters .mini-poster img {
+  height: 200px;
+  width: 300px;
+}
+
+.unmotivational-posters .mini-poster h2,
+.unmotivational-posters .mini-poster h4 {
+  color: white;
+  line-height: 1;
+  width: 90%;
+}
+
+.unmotivational-posters .mini-poster h2 {
+  font-size: 30px;
+  font-weight: normal;
+  letter-spacing: 5px;
+  margin-bottom: 10px;
+  text-transform: uppercase;
+}

--- a/styles.css
+++ b/styles.css
@@ -164,6 +164,8 @@ button:hover {
   height: 340px;
   padding: 25px;
   width: 425px;
+  background: grey; /* Grey padding */
+  border-radius: 10px; /* Rounded edges */
 }
 
 .unmotivational-posters .mini-poster img {
@@ -173,7 +175,6 @@ button:hover {
 
 .unmotivational-posters .mini-poster h2,
 .unmotivational-posters .mini-poster h4 {
-  color: white;
   line-height: 1;
   width: 90%;
 }
@@ -184,4 +185,5 @@ button:hover {
   letter-spacing: 5px;
   margin-bottom: 10px;
   text-transform: uppercase;
+  color: black; /* Black text color */
 }

--- a/styles.css
+++ b/styles.css
@@ -110,9 +110,10 @@ button:hover {
 }
 
 .saved-posters-grid {
-  display: grid;
-  grid-template-columns: repeat(3, 1fr);  /*  this will create 3 columns, 1fr is used to make the columns equal width */
-  grid-gap: 20px;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 20px;
   padding: 20px;
 }
 


### PR DESCRIPTION
This pull request includes updates to the styling and layout of the "Unmotivational Posters" feature in the application. The changes focus on ensuring consistency with the rest of the app and improving the responsiveness of the layout.

Styling Updates:

* Updated the `README.md` to include details about the new styling requirements for the "Unmotivational Posters" button and the "Back to Main" button, ensuring they match other buttons in the app.
* Applied CSS flexbox to the `.saved-posters-grid` and `.unmotivational-posters-grid` classes to create a responsive layout, replacing the previous grid layout. [[1]](diffhunk://#diff-380b7b38760dd442e897eb0164c58f6a17da966ccaca6318017a468c163979b1L113-R116) [[2]](diffhunk://#diff-380b7b38760dd442e897eb0164c58f6a17da966ccaca6318017a468c163979b1L154-R190)

Layout and Appearance:

* Updated the `.unmotivational-posters .mini-poster` class to include grey padding, rounded edges, and black text color, differentiating the unmotivational posters from the saved posters.